### PR TITLE
feat(dev): Cloudflare Tunnel support and domain-based dev; configurab…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,20 @@
 # Absolute host path to your media root (e.g., /mnt/media or /Users/kyle/Media)
 MEDIA_HOST_PATH=/absolute/path/to/media
 TMDB_API_KEY=<TheMovieDB API Key>
+
+# Dev domains for Caddy (used in Caddyfile.dev)
+DEV_DOMAIN=domain.tld
+API_DEV_DOMAIN=api.domain.tld
+
+# Optional: allow your HTTPS origin in CORS (JSON array)
+# LHMM__CORS__ALLOWED_ORIGINS=["https://domain.tld"]
+
+# Dev domains (consumed by Vite and docs)
+DEV_DOMAIN=lhmm.dev
+API_DEV_DOMAIN=api.lhmm.dev
+
+# Cloudflare Tunnel (Zero Trust → Access → Tunnels → Create Tunnel → copy token)
+CLOUDFLARE_TUNNEL_TOKEN=<paste_token_here>
+
+# CORS allow-list for your HTTPS origin (backend)
+# LHMM__CORS__ALLOWED_ORIGINS=["https://lhmm.dev"]

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ config/cache/
 
 # Prompts and internal docs
 .internal/
+
+# local env
+.env
+# cloudflare tunnel cache
+.cloudflared/
+# old caddy artifacts (if any linger locally)
+caddy-root-ca.crt
+caddy-root-ca.crt.sha_and_pem

--- a/README.md
+++ b/README.md
@@ -58,3 +58,31 @@ npm create vite@latest web -- --template react-ts && cd web && npm i
 - Logs: `/lhmm/logs`
 - Media root: `/lhmm/media`
 
+## Dev over Cloudflare Tunnel (no ports, real HTTPS)
+Use a Cloudflare Tunnel sidecar to expose the dev UI/API on your real domains without opening ports.
+
+**Setup**
+1. In Cloudflare → Zero Trust → Access → Tunnels → Create Tunnel. Copy the token.
+2. Add to `.env`:
+   ```
+   DEV_DOMAIN=lhmm.dev
+   API_DEV_DOMAIN=api.lhmm.dev
+   CLOUDFLARE_TUNNEL_TOKEN=...token...
+   LHMM__CORS__ALLOWED_ORIGINS='["https://lhmm.dev"]'
+   ```
+3. In the Tunnel Public Hostnames, add:
+   - `lhmm.dev` → HTTP → `web:5173`
+   - `api.lhmm.dev` → HTTP → `server:8080`
+4. Start:
+   ```
+   docker compose -f docker-compose.dev.yml up -d
+   ```
+5. Test:
+   - https://lhmm.dev
+   - https://api.lhmm.dev/api/v1/healthz
+   - https://api.lhmm.dev/api/v1/tmdb/search?q=dune
+
+Notes:
+- Vite HMR uses WSS via `DEV_DOMAIN` (no port URLs).
+- Backend CORS is controlled via config/env (`LHMM__CORS__ALLOWED_ORIGINS`).
+

--- a/config/default.yml
+++ b/config/default.yml
@@ -30,3 +30,6 @@ auth:
     username: ""
     password: ""
 
+cors:
+  allowed_origins:
+    - http://localhost:5173

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,9 +24,7 @@ services:
       - ./web:/lhmm/app/frontend
       - /Volumes/kdev/lhmm-demo/config:/lhmm/config
       - /Volumes/kdev/lhmm-demo/logs:/lhmm/logs
-      - /Volumes/kdev/lhmm-demo/media:/lhmm/media
-    ports:
-      - "8080:8080"
+      - /Volumes/media:/lhmm/media
     networks: [lhmmnet]
 
   web:
@@ -36,12 +34,22 @@ services:
     working_dir: /lhmm/app/frontend
     command: sh -lc 'if [ -f package-lock.json ]; then npm ci; else npm install; fi && npm run dev -- --host 0.0.0.0 --port 5173 --strictPort'
     environment:
-      CHOKIDAR_USEPOLLING: "1"
+      - CHOKIDAR_USEPOLLING=1
+      - DEV_DOMAIN=${DEV_DOMAIN}
     volumes:
       - ./web:/lhmm/app/frontend
-    ports:
-      - "5173:5173"
     depends_on: [server]
+    networks: [lhmmnet]
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: lhmm-cloudflared
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - server
+      - web
     networks: [lhmmnet]
   
 networks:

--- a/server/lhmm/main.py
+++ b/server/lhmm/main.py
@@ -26,7 +26,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=settings.cors.allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/server/lhmm/settings.py
+++ b/server/lhmm/settings.py
@@ -45,6 +45,9 @@ class BasicAuthCfg(BaseModel):
 class AuthCfg(BaseModel):
     basic: BasicAuthCfg = BasicAuthCfg()
 
+class CorsCfg(BaseModel):
+    allowed_origins: List[str] = Field(default_factory=lambda: ["http://localhost:5173"])
+
 class Settings(BaseModel):
     logging: LoggingCfg = LoggingCfg()
     db: DBCfg = DBCfg()
@@ -54,6 +57,7 @@ class Settings(BaseModel):
     sabnzbd: SABCfg = SABCfg()
     indexers: List[IndexerCfg] = Field(default_factory=list)
     auth: AuthCfg = AuthCfg()
+    cors: CorsCfg = CorsCfg()
 
 def _deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
     out = dict(a)

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+const DEV_DOMAIN = process.env.DEV_DOMAIN || 'lhmm.dev'
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    strictPort: true,
+    allowedHosts: [DEV_DOMAIN, 'localhost'],
+    hmr: {
+      host: DEV_DOMAIN,
+      protocol: 'wss',
+      clientPort: 443,
+    },
+  },
 })


### PR DESCRIPTION
## Summary
Cloudflare Tunnel support and domain-based dev; configurable CORS

## Changes
- Add cloudflared sidecar to docker-compose.dev
- Parameterize DEV_DOMAIN/API_DEV_DOMAIN and CLOUDFLARE_TUNNEL_TOKEN
- Configure Vite for allowedHosts and WSS HMR via DEV_DOMAIN
- Introduce cors.allowed_origins and use in FastAPI
- Update .gitignore and README
- Adjust media volume and remove exposed dev ports

BREAKING CHANGE: dev ports 8080/5173 are no longer published; access via Cloudflare Tunnel domains.

## Impact (tick those that apply)
- [x] API surface changed (endpoints/shape)
- [x] Config changed (new keys or defaults)
- [ ] DB migration
- [ ] UI visible change

## Checklist
- [x] Local build and run green locally
- [x] Updated docs (if necessary)
- [x] No errors in logs.