### PR TITLE
Feat/api disks libraries

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
       LHMM_MEDIA_ROOT: /lhmm/media
       LHMM_DB_URL: sqlite:////lhmm/config/db/lhmm.sqlite3
       LHMM__TMDB__API_KEY: ${TMDB_API_KEY}
+      LHMM__CORS__ALLOWED_ORIGINS: ${LHMM__CORS__ALLOWED_ORIGINS}
     volumes:
       - ./server:/lhmm/app/backend
       - ./web:/lhmm/app/frontend

--- a/server/lhmm/api/__init__.py
+++ b/server/lhmm/api/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/server/lhmm/api/deps.py
+++ b/server/lhmm/api/deps.py
@@ -1,0 +1,16 @@
+from typing import Generator
+from sqlalchemy.orm import Session
+from lhmm.db.session import SessionLocal
+
+# FastAPI dependency: yield a DB session and ensure proper commit/rollback
+# NOTE: Do NOT use @contextmanager here; FastAPI expects a generator function.
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/server/lhmm/api/errors.py
+++ b/server/lhmm/api/errors.py
@@ -1,0 +1,9 @@
+from fastapi import HTTPException
+
+
+def bad_request(message: str, details: dict | None = None) -> HTTPException:
+    return HTTPException(status_code=400, detail={"error": {"code": "bad_request", "message": message, "details": details or {}}})
+
+
+def not_found(message: str = "Not found") -> HTTPException:
+    return HTTPException(status_code=404, detail={"error": {"code": "not_found", "message": message, "details": {}}})

--- a/server/lhmm/api/pagination.py
+++ b/server/lhmm/api/pagination.py
@@ -1,0 +1,12 @@
+from typing import Tuple
+
+
+def parse_pagination(page: int = 1, per_page: int = 50, max_per_page: int = 100) -> Tuple[int, int]:
+    if page < 1:
+        page = 1
+    if per_page < 1:
+        per_page = 1
+    if per_page > max_per_page:
+        per_page = max_per_page
+    offset = (page - 1) * per_page
+    return offset, per_page

--- a/server/lhmm/api/v1/__init__.py
+++ b/server/lhmm/api/v1/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/server/lhmm/api/v1/disks.py
+++ b/server/lhmm/api/v1/disks.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session
+from lhmm.db.models import Disk, Library
+from lhmm.api.deps import get_db
+from lhmm.api.pagination import parse_pagination
+from lhmm.api.errors import bad_request, not_found
+
+router = APIRouter(prefix="/disks", tags=["disks"])
+
+
+class DiskIn(BaseModel):
+    name: str = Field(min_length=1, max_length=64)
+    mount_path: str = Field(min_length=1, max_length=512)
+
+
+class DiskOut(BaseModel):
+    id: int
+    name: str
+    mount_path: str
+
+    class Config:
+        from_attributes = True
+
+
+@router.get("")
+def list_disks(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=100),
+    sort: str = Query("name"),
+    db: Session = Depends(get_db),
+):
+    offset, limit = parse_pagination(page, per_page)
+    order = Disk.name.asc() if sort == "name" else Disk.name.desc() if sort == "-name" else Disk.id.asc()
+    total = db.scalar(select(func.count()).select_from(Disk)) or 0
+    items = db.execute(select(Disk).order_by(order).offset(offset).limit(limit)).scalars().all()
+    return {
+        "total": total,
+        "page": page,
+        "per_page": limit,
+        "items": [DiskOut.model_validate(i).model_dump() for i in items],
+    }
+
+
+@router.post("")
+def create_disk(payload: DiskIn, db: Session = Depends(get_db)):
+    if db.scalar(select(func.count()).select_from(Disk).where(Disk.name == payload.name)):
+        raise bad_request("Disk name already exists")
+    d = Disk(name=payload.name, mount_path=payload.mount_path)
+    db.add(d)
+    db.flush()
+    return DiskOut.model_validate(d).model_dump()
+
+
+@router.get("/{disk_id}")
+def get_disk(disk_id: int, db: Session = Depends(get_db)):
+    d = db.get(Disk, disk_id)
+    if not d:
+        raise not_found()
+    return DiskOut.model_validate(d).model_dump()
+
+
+@router.put("/{disk_id}")
+def update_disk(disk_id: int, payload: DiskIn, db: Session = Depends(get_db)):
+    d = db.get(Disk, disk_id)
+    if not d:
+        raise not_found()
+    if payload.name != d.name and db.scalar(select(func.count()).select_from(Disk).where(Disk.name == payload.name)):
+        raise bad_request("Disk name already exists")
+    d.name = payload.name
+    d.mount_path = payload.mount_path
+    db.add(d)
+    return DiskOut.model_validate(d).model_dump()
+
+
+@router.delete("/{disk_id}", status_code=204)
+def delete_disk(disk_id: int, db: Session = Depends(get_db)):
+    d = db.get(Disk, disk_id)
+    if not d:
+        return
+    if db.scalar(select(func.count()).select_from(Library).where(Library.root_disk_id == disk_id)):
+        raise bad_request("Disk has libraries; move or delete libraries first")
+    db.delete(d)

--- a/server/lhmm/api/v1/libraries.py
+++ b/server/lhmm/api/v1/libraries.py
@@ -1,0 +1,108 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session
+from lhmm.db.models import Library, Disk
+from lhmm.api.deps import get_db
+from lhmm.api.pagination import parse_pagination
+from lhmm.api.errors import bad_request, not_found
+
+router = APIRouter(prefix="/libraries", tags=["libraries"])
+
+
+class LibraryIn(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    type: str = Field(pattern="^(movie|tv)$")
+    root_disk_id: int
+    root_subdir: str = Field(min_length=1, max_length=256)
+    settings_json: str | None = "{}"
+
+
+class LibraryOut(BaseModel):
+    id: int
+    name: str
+    type: str
+    root_disk_id: int
+    root_subdir: str
+    settings_json: str
+
+    class Config:
+        from_attributes = True
+
+
+def _validate_path_under_disk(db: Session, disk_id: int, root_subdir: str):
+    disk = db.get(Disk, disk_id)
+    if not disk:
+        raise bad_request("Root disk does not exist")
+    if root_subdir.startswith("/") or ".." in root_subdir:
+        raise bad_request("root_subdir must be a relative directory name")
+    return f"{disk.mount_path.rstrip('/')}/{root_subdir}"
+
+
+@router.get("")
+def list_libraries(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=100),
+    sort: str = Query("name"),
+    db: Session = Depends(get_db),
+):
+    offset, limit = parse_pagination(page, per_page)
+    order = Library.name.asc() if sort == "name" else Library.name.desc() if sort == "-name" else Library.id.asc()
+    total = db.scalar(select(func.count()).select_from(Library)) or 0
+    items = db.execute(select(Library).order_by(order).offset(offset).limit(limit)).scalars().all()
+    return {
+        "total": total,
+        "page": page,
+        "per_page": limit,
+        "items": [LibraryOut.model_validate(i).model_dump() for i in items],
+    }
+
+
+@router.post("")
+def create_library(payload: LibraryIn, db: Session = Depends(get_db)):
+    _validate_path_under_disk(db, payload.root_disk_id, payload.root_subdir)
+    if db.scalar(select(func.count()).select_from(Library).where(Library.name == payload.name)):
+        raise bad_request("Library name already exists")
+    li = Library(
+        name=payload.name,
+        type=payload.type,
+        root_disk_id=payload.root_disk_id,
+        root_subdir=payload.root_subdir,
+        settings_json=payload.settings_json or "{}",
+    )
+    db.add(li)
+    db.flush()
+    return LibraryOut.model_validate(li).model_dump()
+
+
+@router.get("/{library_id}")
+def get_library(library_id: int, db: Session = Depends(get_db)):
+    li = db.get(Library, library_id)
+    if not li:
+        raise not_found()
+    return LibraryOut.model_validate(li).model_dump()
+
+
+@router.put("/{library_id}")
+def update_library(library_id: int, payload: LibraryIn, db: Session = Depends(get_db)):
+    _validate_path_under_disk(db, payload.root_disk_id, payload.root_subdir)
+    li = db.get(Library, library_id)
+    if not li:
+        raise not_found()
+    if payload.name != li.name and db.scalar(select(func.count()).select_from(Library).where(Library.name == payload.name)):
+        raise bad_request("Library name already exists")
+    li.name = payload.name
+    li.type = payload.type
+    li.root_disk_id = payload.root_disk_id
+    li.root_subdir = payload.root_subdir
+    li.settings_json = payload.settings_json or "{}"
+    db.add(li)
+    return LibraryOut.model_validate(li).model_dump()
+
+
+@router.delete("/{library_id}", status_code=204)
+def delete_library(library_id: int, db: Session = Depends(get_db)):
+    li = db.get(Library, library_id)
+    if not li:
+        return
+    db.delete(li)

--- a/server/lhmm/main.py
+++ b/server/lhmm/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI, APIRouter
+from fastapi import FastAPI, APIRouter, Request
 from fastapi.middleware.cors import CORSMiddleware
 from lhmm.settings import settings
 from lhmm.logging_config import setup_logging
 from lhmm.api.v1 import tmdb as tmdb_routes
 import os, time
+import logging, time as _time
+try:
+    import ulid as _ulid
+except Exception:  # optional
+    _ulid = None
 
 # make sure log dir exists
 os.makedirs(os.path.dirname(settings.logging.file), exist_ok=True)
@@ -60,6 +65,29 @@ def db_pragma():
         fk = conn.exec_driver_sql("PRAGMA foreign_keys;").scalar()
     return {"journal_mode": jm, "foreign_keys": fk}
 
+from lhmm.api.v1 import disks as disks_routes
+from lhmm.api.v1 import libraries as libraries_routes
+
 api.include_router(tmdb_routes.router)
+api.include_router(disks_routes.router)
+api.include_router(libraries_routes.router)
+
+@app.middleware("http")
+async def request_id_logger(request: Request, call_next):
+    rid = (_ulid.new().str if _ulid else str(int(_time.time() * 1000)))
+    start = _time.perf_counter()
+    response = await call_next(request)
+    dur_ms = int((_time.perf_counter() - start) * 1000)
+    response.headers["X-Request-ID"] = rid
+    logging.getLogger("uvicorn.access").info({
+        "event": "request",
+        "rid": rid,
+        "method": request.method,
+        "path": request.url.path,
+        "status": response.status_code,
+        "dur_ms": dur_ms,
+    })
+    return response
+
 app.include_router(api)
 

--- a/server/scripts/test_api_v1.py
+++ b/server/scripts/test_api_v1.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+import os, asyncio, json, sys, tempfile, pathlib
+
+# Ensure a writable sqlite file-based DB for the test
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+db_path = ROOT / "test_api.sqlite3"
+os.environ["LHMM__DB__URL"] = f"sqlite+pysqlite:///{db_path}"
+
+from lhmm.db.base import Base  # noqa: E402
+from lhmm.db.session import engine  # noqa: E402
+from lhmm.main import app  # noqa: E402
+import httpx  # noqa: E402
+
+# Create tables
+Base.metadata.create_all(bind=engine)
+
+
+async def run():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # Health
+        r = await client.get("/api/v1/healthz")
+        assert r.status_code == 200, r.text
+        assert r.headers.get("X-Request-ID"), "missing request id header"
+        assert r.json().get("ok") is True
+
+        # Initial list disks
+        r = await client.get("/api/v1/disks")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["total"] == 0
+
+        # Create disk
+        r = await client.post("/api/v1/disks", json={"name": "d1", "mount_path": "/tmp/mnt1"})
+        assert r.status_code == 200, r.text
+        disk = r.json()
+        disk_id = disk["id"]
+
+        # Get disk
+        r = await client.get(f"/api/v1/disks/{disk_id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["name"] == "d1"
+
+        # Update disk
+        r = await client.put(f"/api/v1/disks/{disk_id}", json={"name": "d1b", "mount_path": "/tmp/mnt1"})
+        assert r.status_code == 200, r.text
+        assert r.json()["name"] == "d1b"
+
+        # Create library
+        r = await client.post(
+            "/api/v1/libraries",
+            json={
+                "name": "Lib1",
+                "type": "movie",
+                "root_disk_id": disk_id,
+                "root_subdir": "Movies",
+                "settings_json": "{}",
+            },
+        )
+        assert r.status_code == 200, r.text
+        lib = r.json()
+        lib_id = lib["id"]
+
+        # Attempt invalid library path
+        r_bad = await client.post(
+            "/api/v1/libraries",
+            json={
+                "name": "BadLib",
+                "type": "tv",
+                "root_disk_id": disk_id,
+                "root_subdir": "/abs",
+                "settings_json": "{}",
+            },
+        )
+        assert r_bad.status_code == 400, (r_bad.status_code, r_bad.text)
+
+        # Try deleting disk while library exists -> expect 400
+        r = await client.delete(f"/api/v1/disks/{disk_id}")
+        assert r.status_code == 400, r.text
+
+        # Update library
+        r = await client.put(
+            f"/api/v1/libraries/{lib_id}",
+            json={
+                "name": "Lib1b",
+                "type": "movie",
+                "root_disk_id": disk_id,
+                "root_subdir": "Movies",
+                "settings_json": "{}",
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["name"] == "Lib1b"
+
+        # Delete library
+        r = await client.delete(f"/api/v1/libraries/{lib_id}")
+        assert r.status_code == 204, r.text
+
+        # Now delete disk
+        r = await client.delete(f"/api/v1/disks/{disk_id}")
+        assert r.status_code == 204, r.text
+
+        # Final list
+        r = await client.get("/api/v1/disks")
+        assert r.status_code == 200, r.text
+        assert r.json()["total"] == 0
+
+    print("OK")
+
+
+if __name__ == "main" or __name__ == "__main__":
+    try:
+        asyncio.run(run())
+    finally:
+        # Cleanup test DB file
+        try:
+            db_path.unlink()
+        except Exception:
+            pass
+


### PR DESCRIPTION
## Summary
- Introduce api/errors, pagination, and DB dependency
- Implement /api/v1/disks and /api/v1/libraries full CRUD
- Wire routers in main; add request-id JSON access logs
- Add test script for quick smoke checks"

## Impact (tick those that apply)
- [x] API surface changed (endpoints/shape)
- [x] Config changed (new keys or defaults)
- [ ] DB migration
- [ ] UI visible change

## Screenshots (optional)
<img width="692" height="976" alt="CleanShot 2025-08-23-09 46 53" src="https://github.com/user-attachments/assets/54654353-6cb0-461e-83d4-41ca3eab2711" />

## Checklist
- [x] Local build and run green locally
- [x] Updated docs (if necessary)
- [x] No errors in logs.