### PR TITLE
feat(config): editable settings + MB log size + diff logs

### DIFF
--- a/server/lhmm/api/v1/system.py
+++ b/server/lhmm/api/v1/system.py
@@ -1,18 +1,66 @@
 from fastapi import APIRouter
-from lhmm.settings import settings
+from pydantic import BaseModel, conint, confloat, field_validator
+from ...db.session import SessionLocal
+from ...services.config_service import load_config, save_partial
+import logging, json
 
 router = APIRouter(prefix="/system", tags=["system"])
 
+class ConfigPatch(BaseModel):
+    tmdb_api_key: str | None = None
+    log_level: str | None = None
+    log_max_bytes: conint(ge=1) | None = None
+    log_max_mb: confloat(gt=0) | None = None
+    log_backups: conint(ge=0) | None = None
+    cors_allowed_origins: list[str] | str | None = None
+
+    @field_validator("log_level")
+    @classmethod
+    def _lv(cls, v):
+        if v is None: return v
+        v2 = v.upper()
+        if v2 not in {"DEBUG","INFO","WARNING","ERROR","CRITICAL"}:
+            raise ValueError("invalid log_level")
+        return v2
+
 @router.get("/config")
 def get_config():
-    # Return only safe, non-secret parts the UI needs.
-    tmdb_key = settings.tmdb.api_key or ""
-    tmdb_mask = (tmdb_key[:4] + "…" + tmdb_key[-2:]) if len(tmdb_key) >= 8 else ""
-    return {
-        "cors": {"allowed_origins": settings.cors.allowed_origins},
-        "paths": {"media_root": settings.paths.media_root},
-        "db": {"url": settings.db.url},
-        "tmdb": {"api_key_mask": tmdb_mask, "configured": bool(settings.tmdb.api_key)},
-        "sabnzbd": {"url": settings.sabnzbd.url, "configured": bool(settings.sabnzbd.api_key)},
-    }
+    db = SessionLocal()
+    try:
+        return load_config(db)
+    finally:
+        db.close()
+
+@router.put("/config")
+def update_config(patch: ConfigPatch):
+    db = SessionLocal()
+    try:
+        old = load_config(db)
+        payload = {k: v for k, v in patch.model_dump(exclude_unset=True).items() if v is not None}
+        new_cfg = save_partial(db, payload)
+
+        logger = logging.getLogger("lhmm.config")
+        def _mask(k, v):
+            return "***" if k == "tmdb_api_key" and v else v
+        changes = []
+        for k in ("tmdb_api_key","log_level","log_max_bytes","log_backups","cors_allowed_origins"):
+            ov, nv = old.get(k), new_cfg.get(k)
+            if ov != nv:
+                if k == "cors_allowed_origins":
+                    ovd = len(ov or [])
+                    nvd = len(nv or [])
+                    changes.append({"key": k, "old_count": ovd, "new_count": nvd})
+                else:
+                    changes.append({"key": k, "old": _mask(k, ov), "new": _mask(k, nv)})
+        if changes:
+            logger.info({"event":"config.update","changes": changes})
+
+        # apply log level immediately
+        if patch.log_level:
+            lvl = getattr(logging, (patch.log_level or "INFO").upper(), logging.INFO)
+            for name in ("", "uvicorn", "uvicorn.error", "uvicorn.access", "lhmm"):
+                logging.getLogger(name).setLevel(lvl)
+        return {"ok": True, "config": new_cfg, "note": "CORS origins changes require backend restart"}
+    finally:
+        db.commit(); db.close()
 

--- a/server/lhmm/db/models.py
+++ b/server/lhmm/db/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from datetime import datetime, timezone
-from sqlalchemy import String, Integer, BigInteger, ForeignKey, UniqueConstraint, Index
+from sqlalchemy import String, Integer, BigInteger, ForeignKey, UniqueConstraint, Index, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from lhmm.db.base import Base
 
@@ -103,3 +103,8 @@ class Job(Base):
     payload_json: Mapped[str] = mapped_column(String, nullable=False, default="{}")
     started_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     finished_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+class AppConfig(Base):
+    __tablename__ = "app_config"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    data: Mapped[dict] = mapped_column(JSON, default=dict)

--- a/server/lhmm/services/config_service.py
+++ b/server/lhmm/services/config_service.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+from sqlalchemy.orm import Session
+from lhmm.db.models import AppConfig
+import os
+
+DEFAULTS = {
+  "tmdb_api_key": None,
+  "log_level": "INFO",
+  "log_max_bytes": 10_000_000,  # ~10 MB
+  "log_backups": 5,
+  # UI origins only (dev + your domain)
+  "cors_allowed_origins": [
+    "https://lhmm.dev",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:4173"
+  ],
+}
+
+def _ensure_row(db: Session) -> AppConfig:
+  row = db.query(AppConfig).filter_by(id=1).one_or_none()
+  if not row:
+    row = AppConfig(id=1, data=DEFAULTS.copy())
+    db.add(row); db.flush()
+  return row
+
+def _normalize_origins(val):
+  if not val: return []
+  if isinstance(val, str):
+    val = [s.strip() for s in val.split(",")]
+  out = []
+  seen = set()
+  for x in val:
+    if not x: continue
+    k = x.strip().rstrip("/")
+    if k not in seen:
+      seen.add(k); out.append(k)
+  return out
+
+def load_config(db: Session) -> dict:
+  row = _ensure_row(db)
+  cfg = {**DEFAULTS, **(row.data or {})}
+  # env overrides (optional)
+  if os.getenv("TMDB_API_KEY"): cfg["tmdb_api_key"] = os.getenv("TMDB_API_KEY")
+  if os.getenv("LHMM_LOG_LEVEL"): cfg["log_level"] = os.getenv("LHMM_LOG_LEVEL")
+  cfg["cors_allowed_origins"] = _normalize_origins(cfg.get("cors_allowed_origins"))
+  return cfg
+
+def save_partial(db: Session, patch: dict) -> dict:
+  row = _ensure_row(db)
+  merged = {**DEFAULTS, **(row.data or {})}
+  # accept log_max_mb (preferred), or legacy log_max_bytes
+  if "log_max_mb" in patch and patch["log_max_mb"] is not None:
+    merged["log_max_bytes"] = int(float(patch["log_max_mb"]) * 1_000_000)
+  if "log_max_bytes" in patch and patch["log_max_bytes"] is not None:
+    merged["log_max_bytes"] = int(patch["log_max_bytes"])
+  # other fields
+  for k in ("tmdb_api_key","log_level","log_backups"):
+    if k in patch and patch[k] is not None:
+      merged[k] = patch[k]
+  if "cors_allowed_origins" in patch and patch["cors_allowed_origins"] is not None:
+    merged["cors_allowed_origins"] = _normalize_origins(patch["cors_allowed_origins"])
+  row.data = merged
+  db.add(row); db.flush()
+  return merged
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -19,6 +19,9 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
 export const api = {
   health: () => req<string>("healthz"),
   config: () => req<any>("system/config"),
+  system: {
+    updateConfig: (payload: any) => req<any>("system/config", { method: "PUT", body: JSON.stringify(payload) }),
+  },
   disks: { list: () => req<any>("disks") },
   libraries: {
     list: () => req<any>("libraries"),

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,12 +1,93 @@
-import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import { api } from "../lib/api";
-import { Card, Descriptions } from "antd";
+import { Card, Form, Input, Select, InputNumber, Button, Space, Typography, message } from "antd";
+
+const LVL = ["DEBUG","INFO","WARNING","ERROR","CRITICAL"];
 
 export default function Settings() {
-  const { data: cfg } = useQuery({ queryKey:["config"], queryFn: api.config });
+  const { data: cfg, refetch } = useQuery({ queryKey:["config"], queryFn: api.config });
+  const [form] = Form.useForm();
+
+  const mut = useMutation({
+    mutationFn: (payload:any) => api.system.updateConfig(payload),
+    onSuccess: () => { message.success("Saved"); refetch(); },
+    onError: (e:any) => message.error(e.message || "Save failed"),
+  });
+
+  // Keep the form in sync with the fetched config
+  useEffect(() => {
+    if (!cfg) return;
+    form.setFieldsValue({
+      tmdb_api_key: cfg.tmdb_api_key || "",
+      log_level: cfg.log_level || "INFO",
+      log_max_mb: cfg.log_max_bytes ? Math.round(Number(cfg.log_max_bytes)/1_000_000) : 10,
+      log_backups: cfg.log_backups ?? 5,
+      cors_allowed_origins: (cfg.cors_allowed_origins || []).join(", "),
+    });
+  }, [cfg, form]);
+
+  const onFinish = (vals:any) => {
+    const payload:any = { ...vals };
+    if (typeof payload.cors_allowed_origins === "string") {
+      payload.cors_allowed_origins = payload.cors_allowed_origins
+        .split(",")
+        .map((s:string)=>s.trim())
+        .filter(Boolean);
+    }
+    // accept MB; backend converts to bytes
+    if (payload.log_max_mb) {
+      payload.log_max_mb = Number(payload.log_max_mb);
+    }
+    mut.mutate(payload);
+  };
+
   return (
-    <Card title="Settings (read-only)">
-      <pre style={{margin:0}}>{JSON.stringify(cfg, null, 2)}</pre>
-    </Card>
+    <Space direction="vertical" size={16} style={{width:"100%"}}>
+      <Card title="Application Settings">
+        <Form form={form} layout="vertical" initialValues={{
+          tmdb_api_key: "",
+          log_level: "INFO",
+          log_max_mb: 10,
+          log_backups: 5,
+          cors_allowed_origins: "",
+        }} onFinish={onFinish}>
+          <Form.Item label="TMDB API Key" name="tmdb_api_key">
+            <Input.Password placeholder="••••••••" autoComplete="off" />
+          </Form.Item>
+
+          <Form.Item label="Log Level" name="log_level">
+            <Select options={LVL.map(x=>({value:x,label:x}))} style={{maxWidth:220}} />
+          </Form.Item>
+
+          <Form.Item label="Log File Size (MB)" name="log_max_mb">
+            <InputNumber min={1} step={1} style={{maxWidth:260}} />
+          </Form.Item>
+
+          <Form.Item label="Log File Backups" name="log_backups">
+            <InputNumber min={0} max={20} style={{maxWidth:260}} />
+          </Form.Item>
+
+          <Form.Item label="Allowed Origins (comma-separated)" name="cors_allowed_origins">
+            <Input placeholder="https://lhmm.dev, http://localhost:5173, http://127.0.0.1:5173" />
+          </Form.Item>
+
+          <Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit" loading={mut.isPending}>Save</Button>
+              <Button onClick={()=>form.resetFields()}>Reset</Button>
+            </Space>
+          </Form.Item>
+
+          <Typography.Text type="secondary">
+            Note: CORS origin changes require a backend restart to fully apply.
+          </Typography.Text>
+        </Form>
+      </Card>
+
+      <Card title="Current Config (read-only)">
+        <pre style={{margin:0}}>{JSON.stringify(cfg, null, 2)}</pre>
+      </Card>
+    </Space>
   );
 }


### PR DESCRIPTION


## Summary
Made settings editable via UI and adjusted how it was displayed for readability.

## Changes
- add AppConfig persistence & sane CORS defaults
- accept log_max_mb (convert to bytes), keep log_backups
- normalize cors_allowed_origins; env overrides for TMDB/log level
- log config.update diffs (mask secrets; count origin changes)
- ui: Settings form syncs with live cfg; shows log size in MB
- api.ts: add system.updateConfig helper

## Impact (tick those that apply)
- [x] API surface changed (endpoints/shape)
- [x] Config changed (new keys or defaults)
- [ ] DB migration
- [x] UI visible change

## Testing Results
<img width="1164" height="358" alt="CleanShot 2025-08-28-14 03 46" src="https://github.com/user-attachments/assets/0dfbc20b-fc3b-49ee-98b7-1938daf33fad" />

<img width="1398" height="165" alt="CleanShot 2025-08-28-14 04 08" src="https://github.com/user-attachments/assets/c5ac1daf-8523-477a-8a1f-1b22744530e2" />


## Checklist
- [x] Local build and run green locally
- [ ] Updated docs (if necessary)
- [x] No errors in logs.