### PR TITLE
feat(settings+sab): SAB config save/test, live toasts, and form sync

### DIFF
--- a/server/lhmm/api/v1/system.py
+++ b/server/lhmm/api/v1/system.py
@@ -1,18 +1,27 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, conint, confloat, field_validator
 from ...db.session import SessionLocal
 from ...services.config_service import load_config, save_partial
+from ...services.sab import SabClient
 import logging, json
 
 router = APIRouter(prefix="/system", tags=["system"])
 
+from pydantic import BaseModel, conint, confloat, field_validator
+
 class ConfigPatch(BaseModel):
+    # existing
     tmdb_api_key: str | None = None
     log_level: str | None = None
     log_max_bytes: conint(ge=1) | None = None
     log_max_mb: confloat(gt=0) | None = None
     log_backups: conint(ge=0) | None = None
     cors_allowed_origins: list[str] | str | None = None
+    # NEW: SAB
+    sab_url: str | None = None
+    sab_api_key: str | None = None
+    sab_category_movies: str | None = None
+    sab_category_tv: str | None = None
 
     @field_validator("log_level")
     @classmethod
@@ -41,15 +50,16 @@ def update_config(patch: ConfigPatch):
 
         logger = logging.getLogger("lhmm.config")
         def _mask(k, v):
-            return "***" if k == "tmdb_api_key" and v else v
+            return "***" if (k in {"tmdb_api_key","sab_api_key"} and v) else v
         changes = []
-        for k in ("tmdb_api_key","log_level","log_max_bytes","log_backups","cors_allowed_origins"):
+        for k in (
+            "tmdb_api_key","log_level","log_max_bytes","log_backups","cors_allowed_origins",
+            "sab_url","sab_api_key","sab_category_movies","sab_category_tv",
+        ):
             ov, nv = old.get(k), new_cfg.get(k)
             if ov != nv:
                 if k == "cors_allowed_origins":
-                    ovd = len(ov or [])
-                    nvd = len(nv or [])
-                    changes.append({"key": k, "old_count": ovd, "new_count": nvd})
+                    changes.append({"key": k, "old_count": len(ov or []), "new_count": len(nv or [])})
                 else:
                     changes.append({"key": k, "old": _mask(k, ov), "new": _mask(k, nv)})
         if changes:
@@ -63,4 +73,50 @@ def update_config(patch: ConfigPatch):
         return {"ok": True, "config": new_cfg, "note": "CORS origins changes require backend restart"}
     finally:
         db.commit(); db.close()
+
+@router.post("/sab/test")
+async def sab_test():
+    db = SessionLocal()
+    try:
+        cfg = load_config(db)
+    finally:
+        db.close()
+    url = (cfg.get("sab_url") or "").strip()
+    key = (cfg.get("sab_api_key") or "").strip()
+    if not url or not key:
+        raise HTTPException(status_code=400, detail="SABnzbd URL or API key missing")
+    try:
+        ver = await SabClient(url, key).version()
+        logging.getLogger("lhmm.sab").info({"event":"sab.test.ok","url":url})
+        return {"ok": True, "version": ver}
+    except Exception as e:
+        logging.getLogger("lhmm.sab").warning({"event":"sab.test.fail","url":url,"err":str(e)})
+        raise HTTPException(status_code=502, detail=f"SAB test failed: {e}")
+
+# Optional: read-only queue and history
+@router.get("/sab/queue")
+async def sab_queue():
+    db = SessionLocal()
+    try:
+        cfg = load_config(db)
+    finally:
+        db.close()
+    url = (cfg.get("sab_url") or "").strip()
+    key = (cfg.get("sab_api_key") or "").strip()
+    if not url or not key:
+        raise HTTPException(status_code=400, detail="SABnzbd URL or API key missing")
+    return await SabClient(url, key).queue()
+
+@router.get("/sab/history")
+async def sab_history(limit: int = 50):
+    db = SessionLocal()
+    try:
+        cfg = load_config(db)
+    finally:
+        db.close()
+    url = (cfg.get("sab_url") or "").strip()
+    key = (cfg.get("sab_api_key") or "").strip()
+    if not url or not key:
+        raise HTTPException(status_code=400, detail="SABnzbd URL or API key missing")
+    return await SabClient(url, key).history(0, limit)
 

--- a/server/lhmm/services/config_service.py
+++ b/server/lhmm/services/config_service.py
@@ -15,6 +15,11 @@ DEFAULTS = {
     "http://127.0.0.1:5173",
     "http://localhost:4173"
   ],
+  # SABnzbd
+  "sab_url": None,
+  "sab_api_key": None,
+  "sab_category_movies": "movies",
+  "sab_category_tv": "tv",
 }
 
 def _ensure_row(db: Session) -> AppConfig:
@@ -37,6 +42,9 @@ def _normalize_origins(val):
       seen.add(k); out.append(k)
   return out
 
+def _mask_secret(v): 
+  return "***" if v else None
+
 def load_config(db: Session) -> dict:
   row = _ensure_row(db)
   cfg = {**DEFAULTS, **(row.data or {})}
@@ -58,6 +66,10 @@ def save_partial(db: Session, patch: dict) -> dict:
   for k in ("tmdb_api_key","log_level","log_backups"):
     if k in patch and patch[k] is not None:
       merged[k] = patch[k]
+  # SAB settings
+  for k in ("sab_url","sab_api_key","sab_category_movies","sab_category_tv"):
+      if k in patch and patch[k] is not None:
+          merged[k] = patch[k]
   if "cors_allowed_origins" in patch and patch["cors_allowed_origins"] is not None:
     merged["cors_allowed_origins"] = _normalize_origins(patch["cors_allowed_origins"])
   row.data = merged

--- a/server/lhmm/services/sab.py
+++ b/server/lhmm/services/sab.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import httpx
+
+class SabClient:
+    def __init__(self, url: str, api_key: str, timeout=10.0):
+        self.url = url.rstrip("/")
+        self.key = api_key
+        self.timeout = timeout
+
+    async def version(self):
+        params = {"mode":"version","output":"json","apikey":self.key}
+        async with httpx.AsyncClient(timeout=self.timeout) as cx:
+            r = await cx.get(f"{self.url}/api", params=params)
+            r.raise_for_status()
+            return r.json()
+
+    async def queue(self):
+        params = {"mode":"queue","output":"json","apikey":self.key}
+        async with httpx.AsyncClient(timeout=self.timeout) as cx:
+            r = await cx.get(f"{self.url}/api", params=params)
+            r.raise_for_status()
+            return r.json()
+
+    async def history(self, start=0, limit=50):
+        params = {"mode":"history","start":start,"limit":limit,"output":"json","apikey":self.key}
+        async with httpx.AsyncClient(timeout=self.timeout) as cx:
+            r = await cx.get(f"{self.url}/api", params=params)
+            r.raise_for_status()
+            return r.json()
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,6 +22,11 @@ export const api = {
   system: {
     updateConfig: (payload: any) => req<any>("system/config", { method: "PUT", body: JSON.stringify(payload) }),
   },
+  sab: {
+    test: () => req<any>("system/sab/test", { method: "POST" }),
+    queue: () => req<any>("system/sab/queue"),
+    history: (limit=50) => req<any>(`system/sab/history?limit=${limit}`),
+  },
   disks: { list: () => req<any>("disks") },
   libraries: {
     list: () => req<any>("libraries"),

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ConfigProvider, theme as antdTheme } from "antd";
-import App from "./App";
+import { ConfigProvider, theme as antdTheme, App as AntdApp } from "antd";
+import RootApp from "./App";
 import "antd/dist/reset.css";
 import "./index.css";
 
@@ -30,19 +30,19 @@ function AppWithTheme() {
       theme={{
         algorithm: dark ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
         token: {
-          // primary palette: AntD Geek Blue
           colorPrimary: "#1677ff",
-          // dark navy surface tones (works under both algorithms)
-          colorBgLayout: dark ? "#0e1624" : undefined,     // page background
-          colorBgContainer: dark ? "#141b2b" : undefined,  // cards/panels
+          colorBgLayout: dark ? "#0e1624" : undefined,
+          colorBgContainer: dark ? "#141b2b" : undefined,
           colorBorderSecondary: dark ? "#202836" : undefined,
           borderRadius: 12,
         },
       }}
     >
-      <QueryClientProvider client={qc}>
-        <App />
-      </QueryClientProvider>
+      <AntdApp>
+        <QueryClientProvider client={qc}>
+          <RootApp />
+        </QueryClientProvider>
+      </AntdApp>
     </ConfigProvider>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,57 +1,116 @@
-import { useEffect } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api";
-import { Card, Form, Input, Select, InputNumber, Button, Space, Typography, message } from "antd";
+import {
+  App as AntdApp,
+  Card, Form, Input, Select, InputNumber, Button, Space, Typography, Row, Col,
+} from "antd";
 
 const LVL = ["DEBUG","INFO","WARNING","ERROR","CRITICAL"];
 
 export default function Settings() {
+  const { message } = AntdApp.useApp();
+  const qc = useQueryClient();
   const { data: cfg, refetch } = useQuery({ queryKey:["config"], queryFn: api.config });
-  const [form] = Form.useForm();
+  const [appForm] = Form.useForm();
+  const [sabForm] = Form.useForm();
+  const [testing, setTesting] = useState(false);
+  const [savingSab, setSavingSab] = useState(false);
 
-  const mut = useMutation({
+  const mutApp = useMutation({
     mutationFn: (payload:any) => api.system.updateConfig(payload),
-    onSuccess: () => { message.success("Saved"); refetch(); },
-    onError: (e:any) => message.error(e.message || "Save failed"),
+    onSuccess: async () => { message.success("Settings saved"); await refetch(); },
+    onError: (e:any) => message.error(e?.message || "Save failed"),
   });
 
-  // Keep the form in sync with the fetched config
   useEffect(() => {
     if (!cfg) return;
-    form.setFieldsValue({
+    // App settings
+    appForm.setFieldsValue({
       tmdb_api_key: cfg.tmdb_api_key || "",
       log_level: cfg.log_level || "INFO",
       log_max_mb: cfg.log_max_bytes ? Math.round(Number(cfg.log_max_bytes)/1_000_000) : 10,
       log_backups: cfg.log_backups ?? 5,
       cors_allowed_origins: (cfg.cors_allowed_origins || []).join(", "),
     });
-  }, [cfg, form]);
+    // SAB settings
+    sabForm.setFieldsValue({
+      sab_url: cfg.sab_url || "",
+      sab_api_key: cfg.sab_api_key || "",
+      sab_category_movies: cfg.sab_category_movies || "movies",
+      sab_category_tv: cfg.sab_category_tv || "tv",
+    });
+  }, [cfg, appForm, sabForm]);
 
-  const onFinish = (vals:any) => {
+  const onSaveApp = async (vals:any) => {
     const payload:any = { ...vals };
     if (typeof payload.cors_allowed_origins === "string") {
       payload.cors_allowed_origins = payload.cors_allowed_origins
-        .split(",")
-        .map((s:string)=>s.trim())
-        .filter(Boolean);
+        .split(",").map((s:string)=>s.trim()).filter(Boolean);
     }
-    // accept MB; backend converts to bytes
-    if (payload.log_max_mb) {
-      payload.log_max_mb = Number(payload.log_max_mb);
+    if (payload.log_max_mb) payload.log_max_mb = Number(payload.log_max_mb);
+    await mutApp.mutateAsync(payload);
+  };
+
+  const saveSab = async () => {
+    setSavingSab(true);
+    try {
+      const vals = await sabForm.validateFields();
+      const patch:any = {};
+      ["sab_url","sab_api_key","sab_category_movies","sab_category_tv"].forEach(k => patch[k] = vals[k]);
+      await api.system.updateConfig(patch);
+      message.success("SAB settings saved");
+      await refetch();
+    } catch (e:any) {
+      if (e?.errorFields) {
+        message.error("Please correct SAB form errors");
+      } else {
+        message.error(e?.message || "Save failed");
+      }
+    } finally {
+      setSavingSab(false);
     }
-    mut.mutate(payload);
+  };
+
+  const testSab = async () => {
+    setTesting(true);
+    try {
+      // Ensure config has the latest SAB values before hitting backend
+      const vals = sabForm.getFieldsValue();
+      const patch:any = {};
+      let changed = false;
+      ["sab_url","sab_api_key","sab_category_movies","sab_category_tv"].forEach(k => {
+        const cur = (cfg?.[k] ?? "");
+        if ((vals?.[k] ?? "") !== cur) { changed = true; patch[k] = vals[k]; }
+      });
+      if (changed) {
+        await api.system.updateConfig(patch);
+        await refetch();
+      }
+      const res = await api.sab.test();
+      if (res?.ok) {
+        message.success("SAB connection OK");
+      } else {
+        message.warning("SAB responded unexpectedly");
+      }
+    } catch (e:any) {
+      const detail = e?.response?.data?.detail || e?.message || "SAB test failed";
+      message.error(detail);
+    } finally {
+      setTesting(false);
+    }
   };
 
   return (
     <Space direction="vertical" size={16} style={{width:"100%"}}>
       <Card title="Application Settings">
-        <Form form={form} layout="vertical" initialValues={{
+        <Form form={appForm} layout="vertical" initialValues={{
           tmdb_api_key: "",
           log_level: "INFO",
           log_max_mb: 10,
           log_backups: 5,
           cors_allowed_origins: "",
-        }} onFinish={onFinish}>
+        }} onFinish={onSaveApp}>
           <Form.Item label="TMDB API Key" name="tmdb_api_key">
             <Input.Password placeholder="••••••••" autoComplete="off" />
           </Form.Item>
@@ -60,11 +119,11 @@ export default function Settings() {
             <Select options={LVL.map(x=>({value:x,label:x}))} style={{maxWidth:220}} />
           </Form.Item>
 
-          <Form.Item label="Log File Size (MB)" name="log_max_mb">
+          <Form.Item label="Log File Size (MB)" name="log_max_mb" rules={[{type:"number", min:1}] }>
             <InputNumber min={1} step={1} style={{maxWidth:260}} />
           </Form.Item>
 
-          <Form.Item label="Log File Backups" name="log_backups">
+          <Form.Item label="Log File Backups" name="log_backups" rules={[{type:"number", min:0, max:20}] }>
             <InputNumber min={0} max={20} style={{maxWidth:260}} />
           </Form.Item>
 
@@ -74,14 +133,52 @@ export default function Settings() {
 
           <Form.Item>
             <Space>
-              <Button type="primary" htmlType="submit" loading={mut.isPending}>Save</Button>
-              <Button onClick={()=>form.resetFields()}>Reset</Button>
+              <Button type="primary" htmlType="submit" loading={mutApp.isPending}>Save</Button>
+              <Button onClick={()=>appForm.resetFields()}>Reset</Button>
             </Space>
           </Form.Item>
 
           <Typography.Text type="secondary">
             Note: CORS origin changes require a backend restart to fully apply.
           </Typography.Text>
+        </Form>
+      </Card>
+
+      <Card title="Downloads — SABnzbd">
+        <Form form={sabForm} layout="vertical" initialValues={{
+          sab_url: "",
+          sab_api_key: "",
+          sab_category_movies: "movies",
+          sab_category_tv: "tv",
+        }}>
+          <Row gutter={12}>
+            <Col span={12}>
+              <Form.Item label="SABnzbd URL" name="sab_url" rules={[{required:true, message:"URL required"}] }>
+                <Input placeholder="http://127.0.0.1:8080" />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="SABnzbd API Key" name="sab_api_key" rules={[{required:true, message:"API key required"}] }>
+                <Input.Password placeholder="••••••••" />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={12}>
+            <Col span={12}>
+              <Form.Item label="Movies Category" name="sab_category_movies">
+                <Input placeholder="movies" />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="TV Category" name="sab_category_tv">
+                <Input placeholder="tv" />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Space>
+            <Button type="primary" onClick={saveSab} loading={savingSab}>Save</Button>
+            <Button onClick={testSab} loading={testing}>Test Connection</Button>
+          </Space>
         </Form>
       </Card>
 


### PR DESCRIPTION
## Summary
- API: accept SAB fields in /api/v1/system/config (sab_url, sab_api_key, categories)
- Logs: include SAB keys in config.update diff (mask secrets)
- UI: Settings split into App + SAB forms; save-then-test workflow
- UI: Ant Design App provider for reliable message/toast rendering
- UI: Form sync with fetched config; log size shown/edited in MB

## Impact (tick those that apply)
- [x] API surface changed (endpoints/shape)
- [x] Config changed (new keys or defaults)
- [ ] DB migration
- [x] UI visible change

## Testing Results
<img width="1218" height="389" alt="CleanShot 2025-08-29-01 25 12" src="https://github.com/user-attachments/assets/fa5257af-cda0-4163-9803-d4dca8e3e282" />

## Checklist
- [x] Local build and run green locally
- [x] Updated docs (if necessary)
- [x] No errors in logs.